### PR TITLE
CAPI-23 Add auth context to request handling

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-server/default_logic_handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/default_logic_handler.mustache
@@ -2,7 +2,7 @@
 
 -behaviour({{packageName}}_logic_handler).
 
--export([handle_request/2]).
+-export([handle_request/3]).
 {{#authMethods}}
     {{#isApiKey}}
 -export([authorize_api_key/2]).
@@ -15,6 +15,6 @@ authorize_api_key(_, _) -> {true, #{}}.
     {{/isApiKey}}
 {{/authMethods}}
 
-handle_request(OperationID, Req) ->
-    io:format(user, "Got request to process: ~p~n", [{OperationID, Req}]),
+handle_request(OperationID, Req, Context) ->
+    io:format(user, "Got request to process: ~p~n", [{OperationID, Req, Context}]),
     {501, [], <<"Not Implemented">>}.

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
@@ -101,12 +101,13 @@ handle_request_json(
     State = #state{
         operation_id = OperationID,
         logic_handler = LogicHandler,
-        validator_state = ValidatorState
+        validator_state = ValidatorState,
+        context = Context
     }
 ) ->
     case {{packageName}}_api:populate_request(OperationID, Req0, ValidatorState) of
         {ok, Populated, Req1} ->
-            case LogicHandler:handle_request(OperationID, Populated) of
+            case LogicHandler:handle_request(OperationID, Populated, Context) of
                 {Code, Headers, Body} ->
                     {{packageName}}_api:validate_response(OperationID, Code, Body , ValidatorState),
                     PreparedBody = jsx:encode(Body),

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
@@ -28,9 +28,9 @@
 init(_Transport, Req, Opts) ->
     {upgrade, protocol, cowboy_rest, Req, Opts}.
 
-rest_init(Req0, [LogicHandler, ValidatorState]) ->
+rest_init(Req0, [Operations, LogicHandler, ValidatorState]) ->
     {Method, Req} = cowboy_req:method(Req0),
-    OperationID = {{packageName}}_router:get_operation_id(Method, ?MODULE),
+    OperationID = maps:get(Method, Operations, undefined),
     State = #state{
         operation_id = OperationID,
         logic_handler = LogicHandler,

--- a/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache
@@ -1,8 +1,7 @@
 -module({{packageName}}_logic_handler).
 
-{{#hasAuthMethods}}
 -type context() :: #{binary() => any()}.
-{{/hasAuthMethods}}
+
 {{#authMethods}}
     {{#isApiKey}}
 -callback authorize_api_key(ApiKey :: binary(), OperationID :: atom()) -> Result :: boolean() | {boolean(), context()}.
@@ -10,4 +9,4 @@
 {{/authMethods}}
 
 
--callback handle_request(OperationID :: atom(), Request :: any()) ->  {Status :: integer(), [Header :: binary()], Body :: any()}.
+-callback handle_request(OperationID :: atom(), Request :: any(), Context :: context()) ->  {Status :: integer(), [Header :: binary()], Body :: any()}.

--- a/modules/swagger-codegen/src/main/resources/erlang-server/router.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/router.mustache
@@ -1,24 +1,35 @@
 -module({{packageName}}_router).
 
 -export([get_paths/1]).
--export([get_operations/0]).
--export([get_operation_id/2]).
 
 get_paths(LogicHandler) ->
     ValidatorState = prepare_validator(),
-    Paths = lists:usort(maps:fold(
-        fun(_, #{path := Path, handler := Handler}, Acc) ->
-            [{Path, Handler} | Acc]
+    PreparedPaths = maps:fold(
+        fun(Path, #{operations := Operations, handler := Handler}, Acc) ->
+            [{Path, Handler, Operations} | Acc]
         end,
         [],
-        get_operations()
-    )),
+        group_paths()
+    ),
     [
         {'_',
-            [{P, H, [LogicHandler, ValidatorState]} || {P, H} <- Paths]
+            [{P, H, [O, LogicHandler, ValidatorState]} || {P, H, O} <- PreparedPaths]
         }
     ].
 
+group_paths() ->
+    maps:fold(
+        fun(OperationID, #{path := Path, method := Method, handler := Handler}, Acc) ->
+            case maps:find(Path, Acc) of
+                {ok, PathInfo = #{operations := Operations}} ->
+                    maps:put(Path, PathInfo#{operations => maps:put(Method, OperationID, Operations)}, Acc);
+                error ->
+                    maps:put(Path, #{handler => Handler, operations => maps:put(Method, OperationID, #{})}, Acc)
+            end
+        end,
+        #{},
+        get_operations()
+    ).
 
 get_operations() ->
     #{ {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
@@ -28,21 +39,6 @@ get_operations() ->
             handler => '{{classname}}'
         }{{#hasMore}},{{/hasMore}}{{/operation}}{{#hasMore}},{{/hasMore}}{{/operations}}{{/apis}}{{/apiInfo}}
     }.
-
-get_operation_id(Method, Handler) ->
-    get_operation_id(Method, Handler, get_operations()).
-
-get_operation_id(Method, Handler, Operations) ->
-    maps:fold(
-        fun
-            (OperationID, #{method := M, handler := H}, _) when H =:= Handler, M =:= Method ->
-                OperationID;
-            (_, _, Acc) ->
-                Acc
-        end,
-        undefined,
-        Operations
-    ).
 
 prepare_validator() ->
     R = jsx:decode(element(2, file:read_file(get_swagger_path()))),

--- a/modules/swagger-codegen/src/main/resources/erlang-server/router.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/router.mustache
@@ -21,10 +21,14 @@ group_paths() ->
     maps:fold(
         fun(OperationID, #{path := Path, method := Method, handler := Handler}, Acc) ->
             case maps:find(Path, Acc) of
-                {ok, PathInfo = #{operations := Operations}} ->
-                    maps:put(Path, PathInfo#{operations => maps:put(Method, OperationID, Operations)}, Acc);
+                {ok, PathInfo0 = #{operations := Operations0}} ->
+                    Operations = Operations0#{Method => OperationID},
+                    PathInfo = PathInfo0#{operations => Operations},
+                    Acc#{Path => PathInfo};
                 error ->
-                    maps:put(Path, #{handler => Handler, operations => maps:put(Method, OperationID, #{})}, Acc)
+                    Operations = #{Method => OperationID},
+                    PathInfo = #{handler => Handler, operations => Operations},
+                    Acc#{Path => PathInfo}
             end
         end,
         #{},
@@ -34,7 +38,7 @@ group_paths() ->
 get_operations() ->
     #{ {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
         '{{operationId}}' => #{
-            path => "{{path}}",
+            path => "{{basePathWithoutHost}}{{path}}",
             method => <<"{{httpMethod}}">>,
             handler => '{{classname}}'
         }{{#hasMore}},{{/hasMore}}{{/operation}}{{#hasMore}},{{/hasMore}}{{/operations}}{{/apis}}{{/apiInfo}}

--- a/modules/swagger-codegen/src/main/resources/erlang-server/server.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/server.mustache
@@ -14,7 +14,8 @@ child_spec(Id, #{
     AcceptorsPool = ?DEFAULT_ACCEPTORS_POOLSIZE,
     {Transport, TransportOpts} = get_socket_transport(Ip, Port, NetOpts),
     LogicHandler = maps:get(logic_handler, Params, ?DEFAULT_LOGIC_HANDLER),
-    CowboyOpts = get_cowboy_config(LogicHandler),
+    ExtraOpts = maps:get(cowboy_extra_opts, Params, []),
+    CowboyOpts = get_cowboy_config(LogicHandler, ExtraOpts),
     ranch:child_spec({?MODULE, Id}, AcceptorsPool,
         Transport, TransportOpts, cowboy_protocol, CowboyOpts).
 
@@ -30,6 +31,22 @@ get_socket_transport(Ip, Port, Options) ->
             {ranch_tcp, Opts}
     end.
 
-get_cowboy_config(LogicHandler) ->
+get_cowboy_config(LogicHandler, ExtraOpts) ->
+    get_cowboy_config(LogicHandler, ExtraOpts, []).
+
+get_cowboy_config(_LogicHandler, [], Opts) ->
+    Opts;
+
+get_cowboy_config(LogicHandler, [{env, Env} | Rest], Opts) ->
+    NewEnv = case proplists:get_value(dispatch, Env) of
+        undefined -> [get_default_dispatch(LogicHandler) | Env];
+        _ -> Env
+    end,
+    get_cowboy_config(LogicHandler, Rest, [{env, NewEnv} | Opts]);
+
+get_cowboy_config(LogicHandler, [O | Rest], Opts) ->
+    get_cowboy_config(LogicHandler, Rest, [O | Opts]).
+
+get_default_dispatch(LogicHandler) ->
     Paths = swagger_router:get_paths(LogicHandler),
-    [{env, [{dispatch, cowboy_router:compile(Paths)}]}].
+    {dispatch, cowboy_router:compile(Paths)}.


### PR DESCRIPTION
Для получения информации о мерчанте в обработчики запросов нужно отправлять контекст из авторизационного токена
