### PR TITLE
CAPI-23 Fix missed bracket in auth module

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-server/auth.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/auth.mustache
@@ -25,7 +25,7 @@ authorize_api_key(LogicHandler, OperationID, From, KeyParam, Req0) ->
             ),
             case Result of
                 {true, Context}  ->
-                    true, Context, Req};
+                    {true, Context, Req};
                 false ->
                     AuthHeader = <<"">>,
                     {false, AuthHeader, Req}


### PR DESCRIPTION
I managed to fuck it all up right before merge :(
