### PR TITLE
FF-11: bump hackney version to match woody

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-client/rebar.config.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-client/rebar.config.mustache
@@ -3,7 +3,7 @@
 ]}.
 
 {deps, [
-    {hackney,     "1.5.7"},
+    {hackney,     "1.13.0"},
     {jsx,         "2.8.2"},
     {rfc3339,     "0.2.2"},
     {jesse,       {git, "https://github.com/rbkmoney/jesse.git",       {ref, "39105922d1ce5834383d8e8aa877c60319b9834a"}}},


### PR DESCRIPTION
Current version in woody_erlang is 1.13.0 ([proof](https://github.com/rbkmoney/woody_erlang/blob/d8de03d34ac4b296f842e78f2a368c0ec2ff52ff/rebar.config#L10))