### PR TITLE
Adjusted codegen to work with erlang-21 url-shortener

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
@@ -164,15 +164,15 @@ charsets_provided(Req, State) ->
     {Value :: boolean(), Req :: cowboy_req:req(), State :: state()}.
 
 malformed_request(Req, State = #state{context = Context}) ->
-    {PeerResult, Req1} = {{packageName}}_handler_api:determine_peer(Req),
+    PeerResult = {{packageName}}_handler_api:determine_peer(Req),
     case PeerResult of
         {ok, Peer} ->
             Context1 = Context#{peer => Peer},
             State1   = State#state{context = Context1},
-            {false, Req1, State1};
+            {false, Req, State1};
         {error, Reason} ->
             error_logger:error_msg("Unable to determine client peer: ~p", [Reason]),
-            {true, Req1, State}
+            {true, Req, State}
     end.
 
 -spec allow_missing_post(Req :: cowboy_req:req(), State :: state()) ->

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
@@ -5,8 +5,7 @@
 
 %% Cowboy REST callbacks
 -export([allowed_methods/2]).
--export([init/3]).
--export([rest_init/2]).
+-export([init/2]).
 -export([allow_missing_post/2]).
 -export([content_types_accepted/2]).
 -export([content_types_provided/2]).
@@ -29,21 +28,15 @@
 
 -type state()              :: state().
 -type content_type()       :: {binary(), binary(), '*' | [{binary(), binary()}]}.
--type processed_response() :: {halt, cowboy_req:req(), state()}.
+-type processed_response() :: {stop, cowboy_req:req(), state()}.
 
 %% Cowboy REST callbacks
 
--spec init(TransportName :: atom(), Req :: cowboy_req:req(), Opts :: {{packageName}}_router:init_opts()) ->
-    {upgrade, protocol, cowboy_rest, Req :: cowboy_req:req(), Opts :: {{packageName}}_router:init_opts()}.
+-spec init(Req :: cowboy_req:req(), Opts :: {{packageName}}_router:init_opts()) ->
+    {cowboy_rest, Req :: cowboy_req:req(), State :: state()}.
 
-init(_Transport, Req, Opts) ->
-    {upgrade, protocol, cowboy_rest, Req, Opts}.
-
--spec rest_init(Req :: cowboy_req:req(), Opts :: {{packageName}}_router:init_opts()) ->
-    {ok, Req :: cowboy_req:req(), State :: state()}.
-
-rest_init(Req0, {Operations, LogicHandler}) ->
-    {Method, Req1} = cowboy_req:method(Req0),
+init(Req, {Operations, LogicHandler}) ->
+    Method = cowboy_req:method(Req),
     OperationID    = maps:get(Method, Operations, undefined),
 
     error_logger:info_msg("Attempt to process operation: ~p", [OperationID]),
@@ -53,8 +46,7 @@ rest_init(Req0, {Operations, LogicHandler}) ->
         logic_handler = LogicHandler,
         context       = #{}
     },
-
-    {ok, Req1, State}.
+    {cowboy_rest, Req, State}.
 
 -spec allowed_methods(Req :: cowboy_req:req(), State :: state()) ->
     {Value :: [binary()], Req :: cowboy_req:req(), State :: state()}.
@@ -251,7 +243,7 @@ encode_response(Resp) ->
 
 process_response(Status, Result, Req0, State = #state{operation_id = OperationID}) ->
     Req = {{packageName}}_handler_api:process_response(Status, Result, Req0, OperationID),
-    {halt, Req, State}.
+    {stop, Req, State}.
 
 validate_headers(_, Req) ->
     {true, Req}.

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
@@ -184,20 +184,24 @@ determine_peer_from_header(Value, _Peer) when is_binary(Value) ->
     {error, Message :: {{packageName}}:error_reason(), Req :: cowboy_req:req()}.
 
 get_value(body, _Name, Req0) ->
-    {ok, Body, Req} = {{packageName}}_utils:get_body(Req0),
-    case decode_body(Body) of
-        {ok, Value} ->
-            {ok, Value, Req};
+    case {{packageName}}_utils:get_body(Req0) of
+        {ok, Body, Req} ->
+            case decode_body(Body) of
+                {ok, Value} ->
+                    {ok, Value, Req};
+                {error, Message} ->
+                    {error, Message, Req}
+            end;
         {error, Message} ->
-            {error, Message, Req}
+            {error, Message, Req0}
     end;
 get_value(qs_val, Name, Req) ->
     case cowboy_req:match_qs([{Name, [], undefined}], Req) of
-    #{Name := Value} when Value /= undefined ->
-        {ok, Value, Req};
-    #{Name := undefined} ->
-        {error, <<"Invalid query">>}
-end;
+        #{Name := Value} when Value /= undefined ->
+            {ok, Value, Req};
+        #{Name := undefined} ->
+            {error, <<"Invalid query">>}
+    end;
 get_value(header, Name, Req) ->
     Headers = cowboy_req:headers(Req),
     {ok, maps:get({{packageName}}_utils:to_header(Name), Headers, undefined), Req};

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
@@ -68,9 +68,9 @@ authorize_api_key(LogicHandler, OperationID, From, KeyParam, Req0) ->
     }.
 
 determine_peer(Req) ->
-    {Peer, Req1}  = cowboy_req:peer(Req),
-    {Value, Req2} = cowboy_req:header(<<"x-forwarded-for">>, Req1),
-    {determine_peer_from_header(Value, Peer), Req2}.
+    Peer  = cowboy_req:peer(Req),
+    Value = cowboy_req:header(<<"x-forwarded-for">>, Req),
+    {determine_peer_from_header(Value, Peer), Req}.
 
 -spec populate_request(Spec :: request_spec(), Req :: cowboy_req:req()) ->
     {ok,    Populated :: {{packageName}}:object(),       Req :: cowboy_req:req()} |
@@ -93,7 +93,7 @@ validate_response(Spec, RespBody) ->
             erlang:error({response_validation_failed, Error, RespBody})
     end.
 
--spec encode_response(Resp :: {{packageName}}_logic_handler:response()) ->
+-spec encode_response(Resp :: {{packageName}}:response()) ->
     Encoded :: response().
 
 encode_response(Resp = {_, _, undefined}) ->
@@ -109,19 +109,16 @@ encode_response({Code, Headers, Body}) ->
 ) ->
     Req :: cowboy_req:req().
 
-process_response(ok, {Code, Headers, undefined}, Req0, _) ->
-    {ok, Req} = cowboy_req:reply(Code, Headers, Req0),
-    Req;
-process_response(ok, {Code, Headers, Body}, Req0, _) ->
-    {ok, Req} = cowboy_req:reply(Code, Headers, Body, Req0),
-    Req;
-process_response(error, Message, Req0, OperationID) ->
+process_response(ok, {Code, Headers, undefined}, Req, _) ->
+    cowboy_req:reply(Code, Headers, Req);
+process_response(ok, {Code, Headers, Body}, Req, _) ->
+    cowboy_req:reply(Code, Headers, Body, Req);
+process_response(error, Message, Req, OperationID) ->
     error_logger:info_msg(
         "Unable to process request for ~p: ~ts",
         [OperationID, Message]
     ),
-    {ok, Req} = cowboy_req:reply(400, [], Message, Req0),
-    Req.
+    cowboy_req:reply(400, #{}, Message, Req).
 
 
 %% Internal
@@ -190,29 +187,28 @@ determine_peer_from_header(Value, _Peer) when is_binary(Value) ->
     {error, Message :: {{packageName}}:error_reason(), Req :: cowboy_req:req()}.
 
 get_value(body, _Name, Req0) ->
-    {ok, Body, Req} = cowboy_req:body(Req0),
+    {ok, Body, Req} = {{packageName}}_utils:get_body(Req0),
     case decode_body(Body) of
         {ok, Value} ->
             {ok, Value, Req};
         {error, Message} ->
             {error, Message, Req}
     end;
-get_value(qs_val, Name, Req0) ->
-    try cowboy_req:qs_vals(Req0) of
-        {QS, Req} ->
-            Value = {{packageName}}_utils:get_opt({{packageName}}_utils:to_qs(Name), QS),
-            {ok, Value, Req}
+get_value(qs_val, Name, Req) ->
+    try
+        #{Name := Value} = cowboy_req:match_qs(Name, Req),
+        {ok, Value, Req}
     catch
         error:_ ->
             {error, <<"Invalid query">>}
     end;
-get_value(header, Name, Req0) ->
-    {Headers, Req} = cowboy_req:headers(Req0),
-    Value          = {{packageName}}_utils:get_opt({{packageName}}_utils:to_header(Name), Headers),
+get_value(header, Name, Req) ->
+    Headers = cowboy_req:headers(Req), % map here
+    Value  = {{packageName}}_utils:get_opt({{packageName}}_utils:to_header(Name), Headers),
     {ok, Value, Req};
-get_value(binding, Name, Req0) ->
-    {Bindings, Req} = cowboy_req:bindings(Req0),
-    Value           = {{packageName}}_utils:get_opt({{packageName}}_utils:to_binding(Name), Bindings),
+get_value(binding, Name, Req) ->
+    Bindings = cowboy_req:bindings(Req),
+    Value = {{packageName}}_utils:get_opt({{packageName}}_utils:to_binding(Name), Bindings),
     {ok, Value, Req}.
 
 -spec decode_body(Body :: binary()) ->

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
@@ -192,13 +192,12 @@ get_value(body, _Name, Req0) ->
             {error, Message, Req}
     end;
 get_value(qs_val, Name, Req) ->
-    try
-        #{Name := Value} = cowboy_req:match_qs(Name, Req),
-        {ok, Value, Req}
-    catch
-        exit:_ ->
-            {ok, undefined, Req}
-    end;
+    case cowboy_req:match_qs([{Name, [], undefined}], Req) of
+    #{Name := Value} when Value /= undefined ->
+        {ok, Value, Req};
+    #{Name := undefined} ->
+        {error, <<"Invalid query">>}
+end;
 get_value(header, Name, Req) ->
     Headers = cowboy_req:headers(Req),
     {ok, maps:get({{packageName}}_utils:to_header(Name), Headers, undefined), Req};

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
@@ -62,9 +62,7 @@ authorize_api_key(LogicHandler, OperationID, From, KeyParam, Req0) ->
     end.
 
 -spec determine_peer(Req :: cowboy_req:req()) ->
-    {
-        {ok, Peer :: {{packageName}}:client_peer()} | {error, Reason :: malformed | einval}
-    }.
+        {ok, Peer :: {{packageName}}:client_peer()} | {error, Reason :: malformed | einval}.
 
 determine_peer(Req) ->
     Peer  = cowboy_req:peer(Req),
@@ -199,7 +197,7 @@ get_value(qs_val, Name, Req) ->
         {ok, Value, Req}
     catch
         exit:_ ->
-            {error, <<"Invalid query">>}
+            {ok, undefined, Req}
     end;
 get_value(header, Name, Req) ->
     Headers = cowboy_req:headers(Req),

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
@@ -63,14 +63,13 @@ authorize_api_key(LogicHandler, OperationID, From, KeyParam, Req0) ->
 
 -spec determine_peer(Req :: cowboy_req:req()) ->
     {
-        {ok, Peer :: {{packageName}}:client_peer()} | {error, Reason :: malformed | einval},
-        Req :: cowboy_req:req()
+        {ok, Peer :: {{packageName}}:client_peer()} | {error, Reason :: malformed | einval}
     }.
 
 determine_peer(Req) ->
     Peer  = cowboy_req:peer(Req),
     Value = cowboy_req:header(<<"x-forwarded-for">>, Req),
-    {determine_peer_from_header(Value, Peer), Req}.
+    determine_peer_from_header(Value, Peer).
 
 -spec populate_request(Spec :: request_spec(), Req :: cowboy_req:req()) ->
     {ok,    Populated :: {{packageName}}:object(),       Req :: cowboy_req:req()} |
@@ -199,17 +198,15 @@ get_value(qs_val, Name, Req) ->
         #{Name := Value} = cowboy_req:match_qs(Name, Req),
         {ok, Value, Req}
     catch
-        error:_ ->
+        exit:_ ->
             {error, <<"Invalid query">>}
     end;
 get_value(header, Name, Req) ->
-    Headers = cowboy_req:headers(Req), % map here
-    Value  = {{packageName}}_utils:get_opt({{packageName}}_utils:to_header(Name), Headers),
-    {ok, Value, Req};
+    Headers = cowboy_req:headers(Req),
+    {ok, maps:get({{packageName}}_utils:to_header(Name), Headers, undefined), Req};
 get_value(binding, Name, Req) ->
     Bindings = cowboy_req:bindings(Req),
-    Value = {{packageName}}_utils:get_opt({{packageName}}_utils:to_binding(Name), Bindings),
-    {ok, Value, Req}.
+    {ok, maps:get({{packageName}}_utils:to_binding(Name), Bindings, undefined), Req}.
 
 -spec decode_body(Body :: binary()) ->
     {ok,    Decoded :: {{packageName}}:object() | undefined} |

--- a/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache
@@ -43,8 +43,8 @@ handle_request(Handler, OperationID, Request, Context) ->
 -spec authorize_api_key(logic_handler(_), operation_id(), api_key()) ->
     false | {true, auth_context()}.
 authorize_api_key(Handler, OperationID, ApiKey) ->
-    {Module, _Opts} = get_mod_opts(Handler),
-    Module:authorize_api_key(OperationID, ApiKey).
+    {Module, Opts} = get_mod_opts(Handler),
+    Module:authorize_api_key(OperationID, ApiKey, Opts).
     {{/isApiKey}}
 {{/authMethods}}
 

--- a/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache
@@ -35,16 +35,16 @@
     {ok | error, response()}.
 
 handle_request(Handler, OperationID, Request, Context) ->
-    {Module, Opts} = get_mod_opts(Handler),
-    Module:handle_request(OperationID, Request, Context, Opts).
+    {Module, _Opts} = get_mod_opts(Handler),
+    Module:handle_request(OperationID, Request, Context).
 
 {{#authMethods}}
     {{#isApiKey}}
 -spec authorize_api_key(logic_handler(_), operation_id(), api_key()) ->
     false | {true, auth_context()}.
 authorize_api_key(Handler, OperationID, ApiKey) ->
-    {Module, Opts} = get_mod_opts(Handler),
-    Module:authorize_api_key(OperationID, ApiKey, Opts).
+    {Module, _Opts} = get_mod_opts(Handler),
+    Module:authorize_api_key(OperationID, ApiKey).
     {{/isApiKey}}
 {{/authMethods}}
 

--- a/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache
@@ -35,8 +35,8 @@
     {ok | error, response()}.
 
 handle_request(Handler, OperationID, Request, Context) ->
-    {Module, _Opts} = get_mod_opts(Handler),
-    Module:handle_request(OperationID, Request, Context).
+    {Module, Opts} = get_mod_opts(Handler),
+    Module:handle_request(OperationID, Request, Context, Opts).
 
 {{#authMethods}}
     {{#isApiKey}}

--- a/modules/swagger-codegen/src/main/resources/erlang-server/utils.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/utils.mustache
@@ -213,5 +213,9 @@ get_body(Req) ->
 
 -spec get_body(Req, cowboy_req:read_body_opts()) -> {ok, binary(), Req} when Req::cowboy_req:req().
 get_body(Req, Opts) ->
-    {_, Body, Req1} =  cowboy_req:read_body(Req, Opts),
-    {ok, Body, Req1}.
+    case cowboy_req:read_body(Req, Opts) of
+        {ok, Body, Req1} ->
+            {ok, Body, Req1};
+        {more, _, _} ->
+            {error, <<"Body is too long">>}
+    end.

--- a/modules/swagger-codegen/src/main/resources/erlang-server/utils.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/utils.mustache
@@ -213,12 +213,5 @@ get_body(Req) ->
 
 -spec get_body(Req, cowboy_req:read_body_opts()) -> {ok, binary(), Req} when Req::cowboy_req:req().
 get_body(Req, Opts) ->
-    do_get_body(<<>>, Req, Opts).
-
-do_get_body(Body, Req, Opts) ->
-    case cowboy_req:read_body(Req, Opts) of
-        {ok, Body1, Req1} ->
-            {ok, <<Body/binary, Body1/binary>>, Req1};
-        {more, Body1, Req1} ->
-            do_get_body(<<Body/binary, Body1/binary>>, Req1, Opts)
-    end.
+    {_, Body, Req1} =  cowboy_req:read_body(Req, Opts),
+    {ok, Body, Req1}.

--- a/modules/swagger-codegen/src/main/resources/erlang-server/utils.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/utils.mustache
@@ -19,7 +19,8 @@
 -export([priv_path/1]).
 -export([join/1]).
 -export([join/2]).
-
+-export([get_body/1]).
+-export([get_body/2]).
 
 -spec to_binary(iodata() | atom() | number()) -> binary().
 
@@ -96,18 +97,15 @@ binary_to_existing_atom(Bin, Encoding) when is_binary(Bin) ->
             erlang:error(badarg)
     end.
 
--spec get_opt(any(), []) -> any().
+-spec get_opt(any(), #{}) -> any().
 
 get_opt(Key, Opts) ->
     get_opt(Key, Opts, undefined).
 
--spec get_opt(any(), [], any()) -> any().
+-spec get_opt(any(), #{}, any()) -> any().
 
 get_opt(Key, Opts, Default) ->
-    case lists:keyfind(Key, 1, Opts) of
-        {_, Value} -> Value;
-        false -> Default
-    end.
+    maps:get(Key, Opts, Default).
 
 -spec priv_dir() -> file:filename().
 
@@ -208,3 +206,19 @@ join_(_, [H]) ->
 
 join_(Delim, [H | T]) ->
     [H, Delim | join_(Delim, T)].
+
+-spec get_body(Req) -> {ok, binary(), Req} when Req::cowboy_req:req().
+get_body(Req) ->
+    get_body(Req, #{}).
+
+-spec get_body(Req, cowboy_req:read_body_opts()) -> {ok, binary(), Req} when Req::cowboy_req:req().
+get_body(Req, Opts) ->
+    do_get_body(<<>>, Req, Opts).
+
+do_get_body(Body, Req, Opts) ->
+    case cowboy_req:read_body(Req, Opts) of
+        {ok, Body1, Req1} ->
+            {ok, <<Body/binary, Body1/binary>>, Req1};
+        {more, Body1, Req1} ->
+            do_get_body(<<Body/binary, Body1/binary>>, Req1, Opts)
+    end.


### PR DESCRIPTION
Подправил кодген для совместимости с грядущей версией `url-shortener`.
  
  
Есть спорные моменты, связанные с несоответствием количества аргументов в функциях авторизации например.