### PR TITLE
Switched to upstream parse_trans, bumped jesse commit

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-client/rebar.config.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-client/rebar.config.mustache
@@ -6,6 +6,6 @@
     {hackney,     "1.13.0"},
     {jsx,         "2.8.2"},
     {rfc3339,     "0.2.2"},
-    {jesse,       {git, "https://github.com/rbkmoney/jesse.git",       {ref, "39105922d1ce5834383d8e8aa877c60319b9834a"}}},
-    {parse_trans, {git, "https://github.com/rbkmoney/parse_trans.git", {ref, "5ee45f5bfa6c04329bea3281977b774f04c89f11"}}}
+    {jesse,       {git, "https://github.com/rbkmoney/jesse.git",       {ref, "723e835708a022bbce9e57807ecf220b00fb771a"}}},
+    {parse_trans, {git, "https://github.com/uwiger/parse_trans.git",   {ref, "76abb347c3c1d00fb0ccf9e4b43e22b3d2288484"}}}
 ]}.

--- a/modules/swagger-codegen/src/main/resources/erlang-server/rebar.config.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/rebar.config.mustache
@@ -5,6 +5,6 @@
 {deps, [
     {jsx,         "2.8.2"},
     {rfc3339,     "0.2.2"},
-    {jesse,       {git, "https://github.com/rbkmoney/jesse.git",       {ref, "39105922d1ce5834383d8e8aa877c60319b9834a"}}},
-    {parse_trans, {git, "https://github.com/rbkmoney/parse_trans.git", {ref, "5ee45f5bfa6c04329bea3281977b774f04c89f11"}}}
+    {jesse,       {git, "https://github.com/rbkmoney/jesse.git",       {ref, "723e835708a022bbce9e57807ecf220b00fb771a"}}},
+    {parse_trans, {git, "https://github.com/uwiger/parse_trans.git",   {ref, "76abb347c3c1d00fb0ccf9e4b43e22b3d2288484"}}}
 ]}.


### PR DESCRIPTION
Подтянул erlang-21 совместимую версию jesse
Переключился на [upstream версию parse_trans](github.com/uwiger/parse_trans)