### PR TITLE
Bump to hackney 1.15.0

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-client/rebar.config.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-client/rebar.config.mustache
@@ -3,7 +3,7 @@
 ]}.
 
 {deps, [
-    {hackney,     "1.13.0"},
+    {hackney,     "1.15.0"},
     {jsx,         "2.8.2"},
     {rfc3339,     "0.2.2"},
     {jesse,       {git, "https://github.com/rbkmoney/jesse.git",       {ref, "723e835708a022bbce9e57807ecf220b00fb771a"}}},


### PR DESCRIPTION
Бамп `hackney` чтобы заматчиться с [`woody_erlang`](https://github.com/rbkmoney/woody_erlang/blob/master/rebar.config#L10)
