### PR TITLE
Fix error on undefined qs_val

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
@@ -200,7 +200,7 @@ get_value(qs_val, Name, Req) ->
         #{Name := Value} ->
             {ok, Value, Req}
     catch
-        exit:_ ->
+        exit:{request_error, _, _} ->
             {error, <<"Invalid query">>}
     end;
 get_value(header, Name, Req) ->

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
@@ -201,7 +201,7 @@ get_value(qs_val, Name, Req) ->
             {ok, Value, Req}
     catch
         exit:{request_error, _, _} ->
-            {error, <<"Invalid query">>}
+            {error, <<"Invalid query">>, Req}
     end;
 get_value(header, Name, Req) ->
     Headers = cowboy_req:headers(Req),

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
@@ -196,11 +196,12 @@ get_value(body, _Name, Req0) ->
             {error, Message, Req0}
     end;
 get_value(qs_val, Name, Req) ->
-    case cowboy_req:match_qs([{Name, [], undefined}], Req) of
-        #{Name := Value} when Value /= undefined ->
-            {ok, Value, Req};
-        #{Name := undefined} ->
-            {error, <<"Invalid query">>}
+    try cowboy_req:match_qs([{Name, [], undefined}], Req) of
+        #{Name := Value} ->
+            {ok, Value, Req}
+    catch
+        exit:_ ->
+            {error, <<"Invalid querry">>}
     end;
 get_value(header, Name, Req) ->
     Headers = cowboy_req:headers(Req),

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
@@ -201,7 +201,7 @@ get_value(qs_val, Name, Req) ->
             {ok, Value, Req}
     catch
         exit:_ ->
-            {error, <<"Invalid querry">>}
+            {error, <<"Invalid query">>}
     end;
 get_value(header, Name, Req) ->
     Headers = cowboy_req:headers(Req),


### PR DESCRIPTION
Fix for #60 , no longer return `{error, <<"Invalid query">>}` on `cowboy_req:match_qs` undefined result, do so only if it exits