### PR TITLE
MSPF-632: Pass initial cowboy_req object into request context

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
@@ -45,7 +45,7 @@ init(Req, {_Operations, LogicHandler, SwaggerHandlerOpts} = InitOpts) ->
         operation_id  = OperationID,
         logic_handler = LogicHandler,
         swagger_handler_opts = SwaggerHandlerOpts,
-        context       = #{}
+        context       = #{initial_req => Req}
     },
     {cowboy_rest, Req, State}.
 

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
@@ -45,7 +45,7 @@ init(Req, {_Operations, LogicHandler, SwaggerHandlerOpts} = InitOpts) ->
         operation_id  = OperationID,
         logic_handler = LogicHandler,
         swagger_handler_opts = SwaggerHandlerOpts,
-        context       = #{initial_req => Req}
+        context       = #{cowboy_req => Req}
     },
     {cowboy_rest, Req, State}.
 

--- a/modules/swagger-codegen/src/main/resources/erlang-server/types.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/types.mustache
@@ -13,7 +13,6 @@
 -export_type([handler_opts/1]).
 -export_type([status/0]).
 -export_type([headers/0]).
--export_type([req/0]).
 -export_type([response_body/0]).
 -export_type([response/0]).
 
@@ -37,7 +36,7 @@
 -type request_context() :: #{
     auth_context => AuthContext :: auth_context(),
     peer         => client_peer(),
-    initial_req  => req()
+    cowboy_req  => req()
 }.
 
 

--- a/modules/swagger-codegen/src/main/resources/erlang-server/types.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/types.mustache
@@ -13,6 +13,7 @@
 -export_type([handler_opts/1]).
 -export_type([status/0]).
 -export_type([headers/0]).
+-export_type([req/0]).
 -export_type([response_body/0]).
 -export_type([response/0]).
 
@@ -24,6 +25,7 @@
 -type object()          :: map().
 -type status()          :: cowboy:http_status().
 -type headers()         :: cowboy:http_headers().
+-type req()             :: cowboy_req:req().
 -type response_body()   :: object() | [object()] | undefined.
 -type response()        :: {status(), headers(), response_body()}.
 
@@ -34,7 +36,8 @@
 
 -type request_context() :: #{
     auth_context => AuthContext :: auth_context(),
-    peer         => client_peer()
+    peer         => client_peer(),
+    initial_req  => req()
 }.
 
 


### PR DESCRIPTION
Чтобы не страдать с совместимостью хотелось бы оставить его в контексте. Документация ковбоя обозначает `cowboy_req:req()` как "The Req object" и пишет, что он "сontains information about the request and response", потому раскрывать req -> request для названия типов/полей рука не поднялась.