### PR TITLE
erlang: avoid dialyzer warnings

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-client/param_validator.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-client/param_validator.mustache
@@ -17,7 +17,7 @@
     {min, Min :: number(), Type :: exclusive | inclusive} |
     {max_length, MaxLength :: integer()} |
     {min_length, MaxLength :: integer()} |
-    {pattern, Pattern :: string()} |
+    {pattern, Pattern :: iodata() | unicode:charlist()} |
     boolean().
 -type collection_format() ::
     'csv' |

--- a/modules/swagger-codegen/src/main/resources/erlang-client/rebar.config.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-client/rebar.config.mustache
@@ -3,8 +3,8 @@
 ]}.
 
 {deps, [
-    {hackney,     "1.15.1"},
-    {jsx,         "2.9.0"},
+    {hackney,     "1.17.0"},
+    {jsx,         "3.0.0"},
     {jesse,       {git, "https://github.com/rbkmoney/jesse.git",       {ref, "9b980b7f9ce09b6a136fe5a23d404d1b903f3061"}}},
-    {parse_trans, {git, "https://github.com/uwiger/parse_trans.git",   {ref, "76abb347c3c1d00fb0ccf9e4b43e22b3d2288484"}}}
+    {parse_trans, {git, "https://github.com/uwiger/parse_trans.git",   {ref, "8ba366f81789c913cd63d69c6d1da948c200d18a"}}}
 ]}.

--- a/modules/swagger-codegen/src/main/resources/erlang-server/param_validator.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/param_validator.mustache
@@ -10,7 +10,7 @@
     {min, Min :: number(), Type :: exclusive | inclusive} |
     {max_length, MaxLength :: integer()} |
     {min_length, MaxLength :: integer()} |
-    {pattern, Pattern :: string()} |
+    {pattern, Pattern :: iodata() | unicode:charlist()} |
     boolean().
 -type collection_format() ::
     'csv' |
@@ -311,6 +311,6 @@ validate_array_test() ->
     ?assertEqual(error, test_validate({list, 'csv', [{format, 'int32'}]}, <<"10,xyi,12">>)).
 
 test_validate(Rule, Value) ->
-    do_validate(Rule, Value, #{name => 'Test', msg_type => request}, #{}).
+    do_validate(Rule, Value, #{name => 'Test', msg_type => request, operation_id => undefined}, #{}).
 
 -endif.

--- a/modules/swagger-codegen/src/main/resources/erlang-server/rebar.config.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/rebar.config.mustache
@@ -4,7 +4,7 @@
 
 {deps, [
     {email_validator, "1.0.0"},
-    {jsx,         "2.9.0"},
+    {jsx,         "3.0.0"},
     {jesse,       {git, "https://github.com/rbkmoney/jesse.git",       {ref, "9b980b7f9ce09b6a136fe5a23d404d1b903f3061"}}},
-    {parse_trans, {git, "https://github.com/uwiger/parse_trans.git",   {ref, "76abb347c3c1d00fb0ccf9e4b43e22b3d2288484"}}}
+    {parse_trans, {git, "https://github.com/uwiger/parse_trans.git",   {ref, "8ba366f81789c913cd63d69c6d1da948c200d18a"}}}
 ]}.


### PR DESCRIPTION
- fix type spec on param_validator templates for avoid dialyzer warnings
- upgrade all deps on rebar.config templates to latest versions