### PR TITLE
ED-47: Pass request context into authorize_api_key

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
@@ -88,7 +88,8 @@ is_authorized(
         OperationID,
         From,
         '{{keyParamName}}',
-        Req0
+        Req0,
+        Context
     ),
     case Result of
         {true, AuthContext, Req} ->

--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler_api.mustache
@@ -35,12 +35,13 @@
     OperationID  :: {{packageName}}:operation_id(),
     From         :: header | qs_val,
     KeyParam     :: iodata() | atom(),
-    Req          :: cowboy_req:req()
+    Req          :: cowboy_req:req(),
+    Context      :: {{packageName}}:request_context()
 )->
     {true,  Context    :: {{packageName}}:auth_context(), Req ::cowboy_req:req()} |
     {false, AuthHeader :: binary(),                       Req ::cowboy_req:req()}.
 
-authorize_api_key(LogicHandler, OperationID, From, KeyParam, Req0) ->
+authorize_api_key(LogicHandler, OperationID, From, KeyParam, Req0, Context) ->
     {ok, ApiKey, Req} = get_value(From, KeyParam, Req0),
     case ApiKey of
         undefined ->
@@ -50,7 +51,8 @@ authorize_api_key(LogicHandler, OperationID, From, KeyParam, Req0) ->
             Result = {{packageName}}_logic_handler:authorize_api_key(
                 LogicHandler,
                 OperationID,
-                ApiKey
+                ApiKey,
+                Context
             ),
             case Result of
                 {true, Context}  ->

--- a/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache
@@ -22,13 +22,13 @@
 
 {{#authMethods}}
     {{#isApiKey}}
--export([authorize_api_key/3]).
+-export([authorize_api_key/4]).
     {{/isApiKey}}
 {{/authMethods}}
 
 {{#authMethods}}
     {{#isApiKey}}
--callback authorize_api_key(operation_id(), api_key(), handler_opts(_)) ->
+-callback authorize_api_key(operation_id(), api_key(), request_context(), handler_opts(_)) ->
     boolean() | {boolean(), auth_context()}.
     {{/isApiKey}}
 {{/authMethods}}
@@ -57,11 +57,11 @@ map_error(Handler, {Type, Error}) ->
 
 {{#authMethods}}
     {{#isApiKey}}
--spec authorize_api_key(logic_handler(_), operation_id(), api_key()) ->
+-spec authorize_api_key(logic_handler(_), operation_id(), api_key(), request_context()) ->
     false | {true, auth_context()}.
-authorize_api_key(Handler, OperationID, ApiKey) ->
+authorize_api_key(Handler, OperationID, ApiKey, Context) ->
     {Module, Opts} = get_mod_opts(Handler),
-    Module:authorize_api_key(OperationID, ApiKey, Opts).
+    Module:authorize_api_key(OperationID, ApiKey, Context, Opts).
     {{/isApiKey}}
 {{/authMethods}}
 


### PR DESCRIPTION
Наверное было бы хорошо ходить за `AuthData` ещё во время `authorize_api_key`-шага авторизации. Для этого надо пробросить контекст реквеста, чтобы было из чего формировать `TokenSourceContext` для `tokenkeeper`.