### PR TITLE
[erlang-*] Improve ct_expand times for large schemas

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-client/schema.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-client/schema.mustache
@@ -15,8 +15,9 @@ get() ->
     Schema :: map() | no_return().
 enumerate_discriminator_children(Schema = #{?DEFINITIONS := Defs}) ->
     try
-        {Parents, _} = maps:fold(fun check_definition/3, {#{}, #{}}, Defs),
-        maps:fold(fun correct_schema/3, Schema, Parents)
+        Parents = enumerate_parents(Defs),
+        DefsFixed = maps:fold(fun correct_definition/3, Defs, Parents),
+        Schema#{?DEFINITIONS := DefsFixed}
     catch
         _:Error ->
             handle_error(Error)
@@ -29,64 +30,51 @@ enumerate_discriminator_children(_) ->
 handle_error(Error) ->
     erlang:error({schema_invalid, Error}).
 
-check_definition(Name, Schema, Acc) ->
-    Acc1 = check_discriminator(Name, Schema, Acc),
-    check_backrefs(Name, Schema, Acc1).
+enumerate_parents(Definitions) ->
+    maps:fold(
+        fun
+            (Name, #{<<"allOf">> := AllOf}, AccIn) ->
+                lists:foldl(
+                    fun
+                        (#{<<"$ref">> := <<"#/definitions/", Parent/binary>>}, Acc) ->
+                            Schema = maps:get(Parent, Definitions),
+                            Discriminator = maps:get(<<"discriminator">>, Schema, undefined),
+                            add_parent_child(Discriminator, Parent, Name, Acc);
+                        (_Schema, Acc) ->
+                            Acc
+                    end,
+                    AccIn,
+                    AllOf
+                );
+            (Name, #{<<"discriminator">> := _}, Acc) ->
+                add_parent(Name, Acc);
+            (_Name, _Schema, AccIn) ->
+                AccIn
+        end,
+        #{},
+        Definitions
+    ).
 
-check_discriminator(Name, Schema, {Parents, Candidates}) ->
-    case maps:get(<<"discriminator">>, Schema, undefined) of
-        undefined ->
-            {Parents, Candidates};
-        _ ->
-            {
-                Parents#{Name => maps:get(Name, Candidates, [])},
-                maps:without([Name], Candidates)
-            }
-    end.
+add_parent_child(undefined, _Parent, _Child, Acc) ->
+    Acc;
+add_parent_child(_Discriminator, Parent, Child, Acc) ->
+    maps:put(Parent, [Child | maps:get(Parent, Acc, [])], Acc).
 
-check_backrefs(Name, Schema, Acc) ->
-    case maps:get(<<"allOf">>, Schema, undefined) of
-        undefined ->
-            Acc;
-        AllOf ->
-            lists:foldl(fun(E, A) -> check_allOf(E, Name, A) end, Acc, AllOf)
-    end.
-
-check_allOf(#{<<"$ref">> := <<"#/definitions/", Parent/binary>>}, Child, {Parents, Candidates}) ->
-    case maps:get(Parent, Parents, undefined) of
-        undefined ->
-            {Parents, update_candidates(Parent, Child, Candidates)};
-        Children ->
-            {Parents#{Parent => [Child | Children]}, Candidates}
-    end;
-check_allOf(_, _, Acc) ->
+add_parent(Parent, Acc) when not is_map_key(Parent, Acc) ->
+    maps:put(Parent, [], Acc);
+add_parent(_Parent, Acc) ->
     Acc.
 
-update_candidates(Parent, Child, Candidates) ->
-    case maps:get(Parent, Candidates, undefined) of
-        undefined ->
-            Candidates#{Parent => [Child]};
-        Children ->
-            Candidates#{Parent => [Child | Children]}
-    end.
+correct_definition(Parent, Children, Definitions) ->
+    ParentSchema1 = maps:get(Parent, Definitions),
+    Discriminator = maps:get(<<"discriminator">>, ParentSchema1),
+    ParentSchema2 = deep_put([<<"properties">>, Discriminator, <<"enum">>], Children, ParentSchema1),
+    maps:put(Parent, ParentSchema2, Definitions).
 
-correct_schema(Parent, Children, Schema) ->
-    BasePath = [Parent, ?DEFINITIONS],
-    Discr    = maps:get(<<"discriminator">>, get_sub_schema(BasePath, Schema)),
-    update_schema(Children, [<<"enum">>, Discr, <<"properties">> | BasePath], Schema).
-
-update_schema(Value, [], _Schema) ->
-    Value;
-update_schema(Value, [Key | Path], Schema) ->
-    SubSchema0 = get_sub_schema(Path, Schema),
-    SubSchema1 = update_sub_schema(Key, Value, SubSchema0),
-    update_schema(SubSchema1, Path, Schema).
-
-get_sub_schema(ReversedPath, Schema) ->
-    lists:foldr(fun(K, S) -> maps:get(K, S) end, Schema, ReversedPath).
-
-update_sub_schema(Key, Value, Schema) ->
-    Schema#{Key => Value}.
+deep_put([K], V, M) ->
+    M#{K => V};
+deep_put([K | Ks], V, M) ->
+    maps:put(K, deep_put(Ks, V, maps:get(K, M)), M).
 
 -spec get_raw() -> map().
 get_raw() ->
@@ -174,7 +162,12 @@ get_raw() ->
      }}">>).
 
 get_enum(Parent, Discr, Schema) ->
-    lists:sort(get_sub_schema([<<"enum">>, Discr, <<"properties">>, Parent, ?DEFINITIONS], Schema)).
+    lists:sort(deep_get([?DEFINITIONS, Parent, <<"properties">>, Discr, <<"enum">>], Schema)).
+
+deep_get([K], M) ->
+    maps:get(K, M);
+deep_get([K | Ks], M) ->
+    deep_get(Ks, maps:get(K, M)).
 
 -spec test() -> _.
 -spec enumerate_discriminator_children_test() -> _.

--- a/modules/swagger-codegen/src/main/resources/erlang-server/schema.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/schema.mustache
@@ -15,8 +15,9 @@ get() ->
     Schema :: map() | no_return().
 enumerate_discriminator_children(Schema = #{?DEFINITIONS := Defs}) ->
     try
-        {Parents, _} = maps:fold(fun check_definition/3, {#{}, #{}}, Defs),
-        maps:fold(fun correct_schema/3, Schema, Parents)
+        Parents = enumerate_parents(Defs),
+        DefsFixed = maps:fold(fun correct_definition/3, Defs, Parents),
+        Schema#{?DEFINITIONS := DefsFixed}
     catch
         _:Error ->
             handle_error(Error)
@@ -29,64 +30,51 @@ enumerate_discriminator_children(_) ->
 handle_error(Error) ->
     erlang:error({schema_invalid, Error}).
 
-check_definition(Name, Schema, Acc) ->
-    Acc1 = check_discriminator(Name, Schema, Acc),
-    check_backrefs(Name, Schema, Acc1).
+enumerate_parents(Definitions) ->
+    maps:fold(
+        fun
+            (Name, #{<<"allOf">> := AllOf}, AccIn) ->
+                lists:foldl(
+                    fun
+                        (#{<<"$ref">> := <<"#/definitions/", Parent/binary>>}, Acc) ->
+                            Schema = maps:get(Parent, Definitions),
+                            Discriminator = maps:get(<<"discriminator">>, Schema, undefined),
+                            add_parent_child(Discriminator, Parent, Name, Acc);
+                        (_Schema, Acc) ->
+                            Acc
+                    end,
+                    AccIn,
+                    AllOf
+                );
+            (Name, #{<<"discriminator">> := _}, Acc) ->
+                add_parent(Name, Acc);
+            (_Name, _Schema, AccIn) ->
+                AccIn
+        end,
+        #{},
+        Definitions
+    ).
 
-check_discriminator(Name, Schema, {Parents, Candidates}) ->
-    case maps:get(<<"discriminator">>, Schema, undefined) of
-        undefined ->
-            {Parents, Candidates};
-        _ ->
-            {
-                Parents#{Name => maps:get(Name, Candidates, [])},
-                maps:without([Name], Candidates)
-            }
-    end.
+add_parent_child(undefined, _Parent, _Child, Acc) ->
+    Acc;
+add_parent_child(_Discriminator, Parent, Child, Acc) ->
+    maps:put(Parent, [Child | maps:get(Parent, Acc, [])], Acc).
 
-check_backrefs(Name, Schema, Acc) ->
-    case maps:get(<<"allOf">>, Schema, undefined) of
-        undefined ->
-            Acc;
-        AllOf ->
-            lists:foldl(fun(E, A) -> check_allOf(E, Name, A) end, Acc, AllOf)
-    end.
-
-check_allOf(#{<<"$ref">> := <<"#/definitions/", Parent/binary>>}, Child, {Parents, Candidates}) ->
-    case maps:get(Parent, Parents, undefined) of
-        undefined ->
-            {Parents, update_candidates(Parent, Child, Candidates)};
-        Children ->
-            {Parents#{Parent => [Child | Children]}, Candidates}
-    end;
-check_allOf(_, _, Acc) ->
+add_parent(Parent, Acc) when not is_map_key(Parent, Acc) ->
+    maps:put(Parent, [], Acc);
+add_parent(_Parent, Acc) ->
     Acc.
 
-update_candidates(Parent, Child, Candidates) ->
-    case maps:get(Parent, Candidates, undefined) of
-        undefined ->
-            Candidates#{Parent => [Child]};
-        Children ->
-            Candidates#{Parent => [Child | Children]}
-    end.
+correct_definition(Parent, Children, Definitions) ->
+    ParentSchema1 = maps:get(Parent, Definitions),
+    Discriminator = maps:get(<<"discriminator">>, ParentSchema1),
+    ParentSchema2 = deep_put([<<"properties">>, Discriminator, <<"enum">>], Children, ParentSchema1),
+    maps:put(Parent, ParentSchema2, Definitions).
 
-correct_schema(Parent, Children, Schema) ->
-    BasePath = [Parent, ?DEFINITIONS],
-    Discr    = maps:get(<<"discriminator">>, get_sub_schema(BasePath, Schema)),
-    update_schema(Children, [<<"enum">>, Discr, <<"properties">> | BasePath], Schema).
-
-update_schema(Value, [], _Schema) ->
-    Value;
-update_schema(Value, [Key | Path], Schema) ->
-    SubSchema0 = get_sub_schema(Path, Schema),
-    SubSchema1 = update_sub_schema(Key, Value, SubSchema0),
-    update_schema(SubSchema1, Path, Schema).
-
-get_sub_schema(ReversedPath, Schema) ->
-    lists:foldr(fun(K, S) -> maps:get(K, S) end, Schema, ReversedPath).
-
-update_sub_schema(Key, Value, Schema) ->
-    Schema#{Key => Value}.
+deep_put([K], V, M) ->
+    M#{K => V};
+deep_put([K | Ks], V, M) ->
+    maps:put(K, deep_put(Ks, V, maps:get(K, M)), M).
 
 -spec get_raw() -> map().
 get_raw() ->
@@ -174,7 +162,12 @@ get_raw() ->
      }}">>).
 
 get_enum(Parent, Discr, Schema) ->
-    lists:sort(get_sub_schema([<<"enum">>, Discr, <<"properties">>, Parent, ?DEFINITIONS], Schema)).
+    lists:sort(deep_get([?DEFINITIONS, Parent, <<"properties">>, Discr, <<"enum">>], Schema)).
+
+deep_get([K], M) ->
+    maps:get(K, M);
+deep_get([K | Ks], M) ->
+    deep_get(Ks, maps:get(K, M)).
 
 -spec test() -> _.
 -spec enumerate_discriminator_children_test() -> _.


### PR DESCRIPTION
This will make code evaluated through `ct_expand` parse transform perform MUCH faster, especially when given notably large Swagger schema, presumably because of being more friendly to the standard Erlang interpreter employed by `ct_expand`.
