### PR TITLE
+LogicHandler as logic_handler() type

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-server/router.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/router.mustache
@@ -31,7 +31,7 @@
 -export_type([init_opts/0]).
 -export_type([operation_spec/0]).
 
--spec get_paths(LogicHandler :: atom()) ->  [{'_',[{
+-spec get_paths(LogicHandler :: logic_handler(_)) ->  [{'_',[{
     Path :: string(),
     Handler :: atom(),
     InitOpts :: init_opts()
@@ -40,7 +40,7 @@
 get_paths(LogicHandler) ->
     get_paths(LogicHandler, #{}).
 
--spec get_paths(LogicHandler :: atom(), SwaggerHandlerOpts :: swagger_handler_opts()) ->  [{'_',[{
+-spec get_paths(LogicHandler :: logic_handler(_), SwaggerHandlerOpts :: swagger_handler_opts()) ->  [{'_',[{
     Path :: string(),
     Handler :: atom(),
     InitOpts :: init_opts()


### PR DESCRIPTION
swagger позволяет передавать опции в handler (HandlerOptions), но ошибка в спецификации типов ломает диалайзер

приведение спецификации  типа  [get_paths](https://github.com/rbkmoney/swagger-codegen/blob/fx/logic_handler_type/modules/swagger-codegen/src/main/resources/erlang-server/router.mustache#L43)

В соответствие с [get_mod_opts](https://github.com/rbkmoney/swagger-codegen/blob/fx/logic_handler_type/modules/swagger-codegen/src/main/resources/erlang-server/logic_handler.mustache#L70)

