### PR TITLE
fix: Remove warnings

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ErlangClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ErlangClientCodegen.java
@@ -203,6 +203,18 @@ public class ErlangClientCodegen extends DefaultCodegen implements CodegenConfig
         return "_" + name;  // add an underscore to the name
     }
 
+    @Override
+    public String escapeQuotationMark(String input) {
+        // remove ' to avoid code injection
+        return input.replace("'", "");
+    }
+
+    @Override
+    public String escapeUnsafeCharacters(String input) {
+        // ref: http://stackoverflow.com/a/30421295/677735
+        return input.replace("-ifdef", "- if def").replace("-endif", "- end if");
+    }
+
     /**
      * Location to write api files.  You can use the apiPackage() as defined when the class is
      * instantiated


### PR DESCRIPTION
На данный момент в логах кодогенерации пишется множество предупреждений:

```
[main] WARN io.swagger.codegen.DefaultCodegen - escapeQuotationMark should be overridden in the code generator with proper logic to escape single/double quote
[main] WARN io.swagger.codegen.DefaultCodegen - escapeUnsafeCharacters should be overridden in the code generator with proper logic to escape unsafe characters
[main] WARN io.swagger.codegen.ignore.CodegenIgnoreProcessor - Output directory does not exist, or is inaccessible. No file (.swager-codegen-ignore) will be evaluated.
```

Первые 2 – из-за отсутствия переопределения методов в кодогенерации Эрланг-клиента, и как мне кажется, они бессмысленны.

Escape-правила скопированы из `ErlangServerCodegen.java`.